### PR TITLE
Extract only latest release block for GitHub release body

### DIFF
--- a/.github/workflows/Windows_release.yml
+++ b/.github/workflows/Windows_release.yml
@@ -37,6 +37,16 @@ jobs:
       - name: Push Packages
         run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
 
+      - name: "Extract latest release notes"
+        shell: pwsh
+        run: |
+          $content = Get-Content RELEASE_NOTES.md -Raw
+          if ($content -match '(?s)(####.+?)(?=\n####|\z)') {
+            $Matches[1].Trim() | Set-Content RELEASE_NOTES_LATEST.md
+          } else {
+            $content | Set-Content RELEASE_NOTES_LATEST.md
+          }
+
       - name: release
         uses: actions/create-release@v1
         id: create_release
@@ -45,7 +55,7 @@ jobs:
           prerelease: false
           release_name: 'Akka.Hosting ${{ github.ref_name }}'
           tag_name: ${{ github.ref }}
-          body_path: RELEASE_NOTES.md
+          body_path: RELEASE_NOTES_LATEST.md
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- GitHub releases were using the entire RELEASE_NOTES.md, causing every release to contain the full changelog
- Added PowerShell step to extract only the first #### block into RELEASE_NOTES_LATEST.md
- Release action now uses RELEASE_NOTES_LATEST.md instead of the full file